### PR TITLE
Deploy Planning Bot service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
           REPOSITORY: planning-bot
           TAG: ${{ github.sha }}
           CONFIG: ${{ secrets.PLANNING_BOT_CONFIG }}
-        if: false
         run: |
           echo "$CONFIG" > config/prod/config.edn
           docker build -f docker/production/Dockerfile -t $REGISTRY/$REPOSITORY:$TAG .

--- a/terraform/bot.tf
+++ b/terraform/bot.tf
@@ -1,0 +1,16 @@
+resource "nomad_job" "planning_bot" {
+  jobspec = templatefile(
+    "${path.module}/jobs/bot.nomad",
+    {
+      datacenters = [var.datacenter],
+      image       = "${aws_ecr_repository.planning_bot.repository_url}:${data.consul_keys.bot_image.var.tag}"
+    }
+  )
+}
+
+data "consul_keys" "bot_image" {
+  key {
+    name = "tag"
+    path = "internal/planning-bot/backend_tag"
+  }
+}

--- a/terraform/init.tf
+++ b/terraform/init.tf
@@ -6,6 +6,24 @@ provider "aws" {
   }
 }
 
+provider "consul" {
+  address    = "hs.makimo.pl:8501"
+  scheme     = "https"
+  datacenter = var.datacenter
+
+  ca_file   = "ssl/consul-agent-ca.pem"
+  cert_file = "ssl/client.consul.crt"
+  key_file  = "ssl/client.consul.key"
+}
+
+provider "nomad" {
+  address = "https://hs.makimo.pl:4646"
+
+  ca_file   = "ssl/nomad-agent-ca.pem"
+  cert_file = "ssl/client.nomad.crt"
+  key_file  = "ssl/client.nomad.key"
+}
+
 terraform {
   backend "s3" {
     bucket = "makimo-deployments"
@@ -13,4 +31,3 @@ terraform {
     region = "eu-west-1"
   }
 }
-

--- a/terraform/jobs/bot.nomad
+++ b/terraform/jobs/bot.nomad
@@ -4,7 +4,7 @@ job "planning-bot" {
 
   group "bot" {
     network {
-      port "http" { to = 9000 }
+      port "http" { to = 8080 }
     }
 
     task "bot" {

--- a/terraform/jobs/bot.nomad
+++ b/terraform/jobs/bot.nomad
@@ -1,0 +1,29 @@
+job "planning-bot" {
+  datacenters = [%{ for datacenter in datacenters ~}"${datacenter}"%{ endfor ~}]
+  type = "service"
+
+  group "bot" {
+    network {
+      port "http" { to = 9000 }
+    }
+
+    task "bot" {
+      driver = "docker"
+
+      config {
+        image = "${image}"
+        ports = ["http"]
+      }
+
+      resources {
+        cpu = 500
+        memory = 512
+      }
+    }
+
+    service {
+      name = "planning-bot"
+      port = "http"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,6 +2,10 @@ variable "aws_region" {
   default = "eu-west-1"
 }
 
+variable "datacenter" {
+  default = "makimo1"
+}
+
 variable "common_tags" {
   default = {
     Project : "PB",


### PR DESCRIPTION
# Description

This PR deploys Nomad job that will serve as a Planning Bot service.

> **Note:** until we agree on how to handle the authorization on the endpoints for managing the Planning Bot (please see [this discussion](https://makimo.atlassian.net/browse/PB-30)) none of the endpoints is externally available.
