### PR TITLE
Load balancing to Planning Bot

### DIFF
--- a/terraform/bot.tf
+++ b/terraform/bot.tf
@@ -4,6 +4,7 @@ resource "nomad_job" "planning_bot" {
     {
       datacenters = [var.datacenter],
       image       = "${aws_ecr_repository.planning_bot.repository_url}:${data.consul_keys.bot_image.var.tag}"
+      domain      = var.domain
     }
   )
 }

--- a/terraform/jobs/bot.nomad
+++ b/terraform/jobs/bot.nomad
@@ -24,6 +24,10 @@ job "planning-bot" {
     service {
       name = "planning-bot"
       port = "http"
+
+      tags = [
+        "urlprefix-${domain}/"
+      ]
     }
   }
 }

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,0 +1,15 @@
+data "aws_lb" "main" {
+  name = var.external_lb_name
+}
+
+resource "aws_route53_record" "planning_bot" {
+  zone_id = aws_route53_zone.planning_bot.id
+  name    = var.domain
+  type    = "A"
+
+  alias {
+    name                   = data.aws_lb.main.dns_name
+    zone_id                = data.aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -13,3 +13,13 @@ resource "aws_route53_record" "planning_bot" {
     evaluate_target_health = true
   }
 }
+
+data "aws_lb_listener" "https" {
+  load_balancer_arn = data.aws_lb.main.arn
+  port              = 443
+}
+
+resource "aws_lb_listener_certificate" "backend" {
+  listener_arn    = data.aws_lb_listener.https.arn
+  certificate_arn = aws_acm_certificate.planning_bot.arn
+}

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -71,6 +71,18 @@ resource "aws_wafv2_web_acl" "planning_bot" {
         }
       }
     }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "planning-bot-outside-office"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "planning-bot-gateway-acl"
+    sampled_requests_enabled   = false
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,6 +10,10 @@ variable "domain" {
   default = "fistaszek.makimo.pl"
 }
 
+variable "external_lb_name" {
+  default = "hs-external-lb"
+}
+
 variable "common_tags" {
   default = {
     Project : "PB",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,6 +14,10 @@ variable "external_lb_name" {
   default = "hs-external-lb"
 }
 
+variable "office_ip_address" {
+  default = "194.28.48.158"
+}
+
 variable "common_tags" {
   default = {
     Project : "PB",


### PR DESCRIPTION
# Description

This PR sets up the Planning Bot binding to the ALB with WAF rules that should block all attempts to query PB from outside the office network.

## JIRA Issues

* [PB-30](https://makimo.atlassian.net/browse/PB-30)
