### PR TITLE
Register bot service

### DIFF
--- a/terraform/jobs/bot.nomad
+++ b/terraform/jobs/bot.nomad
@@ -28,6 +28,13 @@ job "planning-bot" {
       tags = [
         "urlprefix-${domain}/"
       ]
+
+      check {
+        type = "http"
+        path = "/health"
+        interval = "10s"
+        timeout = "2s"
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

This PR registers the Planning Bot service in Consul by adding the health check definition to Nomad job. This is required by [Fabio](https://fabiolb.net/) to properly route traffic from external load balancer to the service.

## JIRA Issues

* [PB-30](https://makimo.atlassian.net/browse/PB-30)
